### PR TITLE
add remaining autogenerated files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 **.vo
 **.vok
 **.vos
+**.coq-native/
+**Makefile.coq*
+**.ml*


### PR DESCRIPTION
as discussed during the last lecture. This results in a clean tree after doing the default compile with `make`. 